### PR TITLE
fix(debian): 移除 armhf 架构支持，更新交叉编译环境配置

### DIFF
--- a/.github/workflows/pkg-deb.yml
+++ b/.github/workflows/pkg-deb.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [amd64, arm64, armhf]
+        arch: [amd64, arm64]
     
     steps:
     - name: Checkout repository
@@ -48,7 +48,7 @@ jobs:
       run: |
         sudo dpkg --add-architecture ${{ matrix.arch }}
         sudo apt-get update
-        sudo apt-get install -y gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf crossbuild-essential-${{ matrix.arch }}
+        sudo apt-get install -y gcc-aarch64-linux-gnu crossbuild-essential-${{ matrix.arch }}
         
     - name: Update debian/changelog with version
       run: |
@@ -72,12 +72,6 @@ jobs:
       if: matrix.arch == 'arm64'
       run: |
         echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-        echo "DEB_BUILD_OPTIONS=nocheck" >> $GITHUB_ENV
-        
-    - name: Configure cross-compilation for armhf
-      if: matrix.arch == 'armhf'
-      run: |
-        echo "CC=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
         echo "DEB_BUILD_OPTIONS=nocheck" >> $GITHUB_ENV
         
     - name: Build DEB package


### PR DESCRIPTION
## 描述

### 问题的背景

简要说明此 PR 修复的具体问题或改进的功能背景

例如：

- 当前 `chsrc list` 命令无法正确排序镜像源列表
- `chsrc measure` 命令不支持IPv6测速
- `chsrc set` 命令的源选择逻辑不够智能，无法自动选择最快源

### 相关 issue

列出与此 PR 相关的 issue 或任务，若没有填 `N/A`

例如：

- Closes `#123` (修复了`list`命令的问题)
- Depends on `#789` (等待依赖PR的合并)

### 这个PR做了什么

简要描述本PR的改动内容

例如：

- 修复了 `list` 命令的排序问题
- 增加了对 IPv6 的测速支持
- 优化了 `set` 命令的源选择逻辑

---

## 方案

简要描述针对该问题或功能改进的解决方案

例如：

- 对 `list` 命令进行了排序优化，确保镜像源按照正确的顺序展示
- 在 `measure` 命令中加入了 `-ipv6` 选项，支持 IPv6 测速
- 对 `set` 命令进行了改进，加入了自动选择最快镜像源的逻辑

---

## 实现

详细描述本 PR 的具体实现，包括代码改动的关键点和实现方式

例如：

- 在 `list` 命令中使用新的排序算法
- 在 `measure` 命令中添加了IPv6支持，具体通过解析 `-ipv6` 选项来启用
- 修改了 `set` 命令的源选择逻辑，通过测速算法选择最快源

---

## 注意

列出需要特别注意的事项

例如：

- `-ipv6` 选项需要网络环境支持 IPv6地址，测试时请确保 IPv6 可用
- 在使用 `-dry` 选项进行模拟时，命令只会打印过程，而不会实际执行更换源操作
- 此 PR 向后兼容，原有命令和选项不受影响

---

## 测试

描述如何验证本 PR，列出具体的测试步骤

例如：

- 运行 `chsrc list` 命令，验证镜像源是否按正确的顺序列出
- 使用 `chsrc measure <target> -ipv6` 进行 IPv6 测速，确保能够正常测速
- 运行 `chsrc set <target>` 命令，验证是否能够自动选择最快的源并成功更换

---
